### PR TITLE
feat: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @humanitec-architecture/humanitec


### PR DESCRIPTION
Add CODEOWNERS to automatically ping folks for reviews.

The team is created in https://github.com/orgs/humanitec-architecture/teams/humanitec

More details are in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners