### PR TITLE
fix: missing backend:get-environment & github scaffolder actions

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@backstage/backend-common": "^0.21.7",
     "@backstage/backend-defaults": "^0.2.17",
+    "@backstage/backend-plugin-api": "^0.6.17",
     "@backstage/backend-tasks": "^0.5.22",
     "@backstage/config": "^1.2.0",
     "@backstage/plugin-app-backend": "^0.3.65",
@@ -33,6 +34,7 @@
     "@backstage/plugin-permission-node": "^0.7.28",
     "@backstage/plugin-proxy-backend": "^0.4.15",
     "@backstage/plugin-scaffolder-backend": "^1.22.4",
+    "@backstage/plugin-scaffolder-node": "^0.4.3",
     "@backstage/plugin-search-backend": "^1.5.7",
     "@backstage/plugin-search-backend-module-catalog": "^0.1.22",
     "@backstage/plugin-search-backend-module-techdocs": "^0.1.22",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -34,6 +34,7 @@
     "@backstage/plugin-permission-node": "^0.7.28",
     "@backstage/plugin-proxy-backend": "^0.4.15",
     "@backstage/plugin-scaffolder-backend": "^1.22.4",
+    "@backstage/plugin-scaffolder-backend-module-github": "^0.2.7",
     "@backstage/plugin-scaffolder-node": "^0.4.3",
     "@backstage/plugin-search-backend": "^1.5.7",
     "@backstage/plugin-search-backend-module-catalog": "^0.1.22",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -42,4 +42,7 @@ backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
 backend.add(import('@humanitec/backstage-plugin-backend'));
 backend.add(import('@humanitec/backstage-plugin-scaffolder-backend-module'));
 
+// backend:get-environment used in humanitec templates
+backend.add(import('./actions/get-environment'));
+
 backend.start();

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -12,7 +12,6 @@ const backend = createBackend();
 
 backend.add(import('@backstage/plugin-app-backend/alpha'));
 backend.add(import('@backstage/plugin-proxy-backend/alpha'));
-backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
 backend.add(import('@backstage/plugin-techdocs-backend/alpha'));
 
 // auth plugin
@@ -38,11 +37,15 @@ backend.add(import('@backstage/plugin-search-backend/alpha'));
 backend.add(import('@backstage/plugin-search-backend-module-catalog/alpha'));
 backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
 
+// scaffolder plugin
+backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
+backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
+// backend:get-environment used in humanitec templates
+backend.add(import('./actions/get-environment'));
+
 // humanitec
 backend.add(import('@humanitec/backstage-plugin-backend'));
 backend.add(import('@humanitec/backstage-plugin-scaffolder-backend-module'));
 
-// backend:get-environment used in humanitec templates
-backend.add(import('./actions/get-environment'));
 
 backend.start();


### PR DESCRIPTION
The `backend:get-environment` and `github:` actions were accidentally removed in https://github.com/humanitec-architecture/backstage/pull/21