### PR TITLE
Bump dependencies + `devcontainer` + `Makefile` + `node-service` improvement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,16 +37,9 @@ jobs:
             score.yaml
       - name: humctl score validate - node-service
         run: |
-          score_file=templates/node-service/content/score.yaml
-          # Replace template string with actual values, sadly no better way yet
-          # https://github.com/backstage/backstage/issues/13668
-          sed -i -e 's/${{ '${{ values.name | dump }}' }}/test-workload/g' "$score_file"
           humctl score validate --local --strict \
-            "$score_file"
+            templates/node-service/content/score.yaml
       - name: humctl score validate - podinfo
         run: |
-          score_file=templates/podinfo-example/content/score.yaml
-          # Replace template string with actual values
-          sed -i -e 's/${{ '${{ values.name | dump }}' }}/test-workload/g' "$score_file"
           humctl score validate --local --strict \
-            "$score_file"
+            templates/podinfo-example/content/score.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: docker build podinfo
         run: |
           docker image build -t podinfo:latest templates/podinfo-example/content/
@@ -27,7 +27,7 @@ jobs:
       HUMCTL_VERSION: '0.23.1'
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: humanitec/setup-cli-action@v1
         with:
           version: ${{ env.HUMCTL_VERSION }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ vars.CLOUD_PROVIDER }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure correct org after copying from template
         run: |
@@ -48,7 +48,7 @@ jobs:
           # Ensure correct humanitec org
           sed -i 's/humanitec-architecture/${{ vars.HUMANITEC_ORG_ID }}/g' catalog-info.yaml
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: 'catalog-info.yaml templates/*.yaml'
 
@@ -75,7 +75,7 @@ jobs:
 
       - if: ${{ vars.CLOUD_PROVIDER == 'azure' }}
         name: configure azure credentials
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}

--- a/templates/node-service/content/.devcontainer/devcontainer.json
+++ b/templates/node-service/content/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "Score & Humanitec Dev Container",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		}
+	},
+	"postCreateCommand": "bash .devcontainer/installMoreTools.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"redhat.vscode-yaml"
+			],
+			"settings": {
+				"yaml.schemas": {
+					"https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
+				}
+			}
+		}
+	}
+}

--- a/templates/node-service/content/.devcontainer/installMoreTools.sh
+++ b/templates/node-service/content/.devcontainer/installMoreTools.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+mkdir install-more-tools
+cd install-more-tools
+
+SCORE_COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-compose/releases/latest | jq -r .tag_name)
+wget https://github.com/score-spec/score-compose/releases/download/${SCORE_COMPOSE_VERSION}/score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+tar -xvf score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+chmod +x score-compose
+sudo mv score-compose /usr/local/bin
+
+HUMCTL_VERSION=$(curl -sL https://api.github.com/repos/humanitec/cli/releases/latest | jq -r .tag_name)
+curl -fLO https://github.com/humanitec/cli/releases/download/${HUMCTL_VERSION}/cli_${HUMCTL_VERSION:1}_linux_amd64.tar.gz
+tar -xvf cli_${HUMCTL_VERSION:1}_linux_amd64.tar.gz
+chmod +x humctl
+sudo mv humctl /usr/local/bin/humctl
+
+KIND_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+cd ..
+rm -rf install-more-tools

--- a/templates/node-service/content/.gitignore
+++ b/templates/node-service/content/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+compose.yaml
+values.yaml
+.score-compose/

--- a/templates/node-service/content/Dockerfile
+++ b/templates/node-service/content/Dockerfile
@@ -1,15 +1,11 @@
-FROM alpine:3.18.3
-
-# Install nodejs
+FROM alpine:3.19.1 as builder
 RUN apk add --no-cache nodejs npm
-
 COPY package*.json ./
-RUN npm install
+RUN npm install --only=prod
 
+FROM alpine:3.19.1
+RUN apk add --no-cache nodejs
+COPY --from=builder /node_modules ./node_modules
 COPY index.js index.js
-
-# Expose port 3000
 EXPOSE 3000
-
-# Run the app
 CMD ["node", "index.js"]

--- a/templates/node-service/content/Makefile
+++ b/templates/node-service/content/Makefile
@@ -18,7 +18,8 @@ compose.yaml: score.yaml
 	score-compose init \
 		--no-sample
 	score-compose generate score.yaml \
-		--build '${CONTAINER_NAME}={"context":".","tags":["${CONTAINER_IMAGE}"]}'
+		--build '${CONTAINER_NAME}={"context":".","tags":["${CONTAINER_IMAGE}"]}' \
+		--override-property containers.${CONTAINER_NAME}.variables.MESSAGE="Hello, Compose!"
 
 ## Generate a compose.yaml file from the score spec and launch it.
 .PHONY: compose-up

--- a/templates/node-service/content/Makefile
+++ b/templates/node-service/content/Makefile
@@ -11,7 +11,7 @@ help:
 .PHONY: .FORCE
 .FORCE:
 
-CONTAINER_NAME = node-test
+CONTAINER_NAME = node-service
 CONTAINER_IMAGE = ${CONTAINER_NAME}:test
 
 compose.yaml: score.yaml

--- a/templates/node-service/content/Makefile
+++ b/templates/node-service/content/Makefile
@@ -1,0 +1,37 @@
+# Disable all the default make stuff
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+## Display a list of the documented make targets
+.PHONY: help
+help:
+	@echo Documented Make targets:
+	@perl -e 'undef $$/; while (<>) { while ($$_ =~ /## (.*?)(?:\n# .*)*\n.PHONY:\s+(\S+).*/mg) { printf "\033[36m%-30s\033[0m %s\n", $$2, $$1 } }' $(MAKEFILE_LIST) | sort
+
+.PHONY: .FORCE
+.FORCE:
+
+CONTAINER_NAME = node-test
+CONTAINER_IMAGE = ${CONTAINER_NAME}:test
+
+compose.yaml: score.yaml
+	score-compose init \
+		--no-sample
+	score-compose generate score.yaml \
+		--build '${CONTAINER_NAME}={"context":".","tags":["${CONTAINER_IMAGE}"]}'
+
+## Generate a compose.yaml file from the score spec and launch it.
+.PHONY: compose-up
+compose-up: compose.yaml
+	docker compose up --build -d --remove-orphans
+
+## Generate a compose.yaml file from the score spec, launch it and test (curl) the exposed container.
+.PHONY: compose-test
+compose-test: compose-up
+	sleep 5
+	curl $$(score-compose resources get-outputs dns.default#${CONTAINER_NAME}.dns --format '{{ .host }}:8080')
+
+## Delete the containers running via compose down.
+.PHONY: compose-down
+compose-down:
+	docker compose down -v --remove-orphans || true

--- a/templates/node-service/content/index.js
+++ b/templates/node-service/content/index.js
@@ -2,8 +2,9 @@ const http = require('http');
 const mysql = require('mysql2');
 
 // create the connection to database
+const host = process.env.DB_HOST || 'localhost';
 const connection = mysql.createConnection({
-  host: process.env.DB_HOST || 'localhost'  ,
+  host,
   user: process.env.DB_USER || 'root',
   password: process.env.DB_PASSWORD || 'secret',
   database: process.env.DB_DATABASE || 'score',
@@ -13,19 +14,22 @@ const connection = mysql.createConnection({
 const requestHandler = async (request, response) => {
   console.log(request.url);
 
-  // Run hello world query
-  const [rows, fields] = await connection.promise().query('SELECT "This is an example application deployed with Score!" as message');
+  const message = process.env.MESSAGE || "Hello, World!";
 
-  const message = rows[0].message;
+  // Run hello world query
+  const [rows, fields] = await connection.promise().query(
+    'SELECT version() as version'
+  );
+  const version = rows[0].version;
 
   const html = `
   <html>
     <body>
-      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
-      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
       <div class="container text-center mt-5 pt-5">
-        <h1>Hello World!</h1>
-        <p>${message}</p>
+      <h1>${message}</h1>
+      <p>This is an application talking to a MySQL <code>${version}</code> database on host <code>${host}</code>, deployed with Score!</p>
       </div>
     </body>
   </html>

--- a/templates/node-service/content/package-lock.json
+++ b/templates/node-service/content/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "hello-world",
+  "name": "$something",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hello-world",
+      "name": "$something",
       "version": "1.0.0",
       "license": "PRIVATE",
       "dependencies": {
-        "mysql2": "^3.1.1"
+        "mysql2": "^3.9.7"
       }
     },
     "node_modules/denque": {
@@ -58,21 +58,29 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.1.1.tgz",
-      "integrity": "sha512-mXz4wEj7AIKPdHQJLJcvq8GJ75BDMH9K4V8Lthra8WH7o/xjV6TXp+dXAXDaMFkLa8YhdZr5X6rxIGQSHPPfhg==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
+      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru-cache": "^7.14.1",
+        "lru-cache": "^8.0.0",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
       },
       "engines": {
         "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "engines": {
+        "node": ">=16.14"
       }
     },
     "node_modules/named-placeholders": {

--- a/templates/node-service/content/package.json
+++ b/templates/node-service/content/package.json
@@ -6,6 +6,6 @@
   "license": "PRIVATE",
   "private": true,
   "dependencies": {
-    "mysql2": "^3.6.0"
+    "mysql2": "^3.9.7"
   }
 }

--- a/templates/node-service/content/score.yaml
+++ b/templates/node-service/content/score.yaml
@@ -1,7 +1,7 @@
 apiVersion: score.dev/v1b1
 
 metadata:
-  name: node-test
+  name: ${{ values.name | dump }}
 
 # Define the ports that this service exposes
 service:
@@ -12,7 +12,7 @@ service:
 
 # Define the containers that make up this service
 containers:
-  node-test:
+  node-service:
     image: . # Set by pipeline
     variables:
       PORT: "3000"

--- a/templates/node-service/content/score.yaml
+++ b/templates/node-service/content/score.yaml
@@ -1,7 +1,7 @@
 apiVersion: score.dev/v1b1
 
 metadata:
-  name: ${{ values.name | dump }}
+  name: node-workload
 
 # Define the ports that this service exposes
 service:

--- a/templates/node-service/content/score.yaml
+++ b/templates/node-service/content/score.yaml
@@ -1,7 +1,7 @@
 apiVersion: score.dev/v1b1
 
 metadata:
-  name: ${{ values.name | dump }}
+  name: node-test
 
 # Define the ports that this service exposes
 service:
@@ -12,7 +12,7 @@ service:
 
 # Define the containers that make up this service
 containers:
-  frontend:
+  node-test:
     image: . # Set by pipeline
     variables:
       PORT: "3000"

--- a/templates/podinfo-example/content/.devcontainer/devcontainer.json
+++ b/templates/podinfo-example/content/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+	"name": "Score & Humanitec Dev Container",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"moby": true,
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "latest"
+		}
+	},
+	"postCreateCommand": "bash .devcontainer/installMoreTools.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"redhat.vscode-yaml"
+			],
+			"settings": {
+				"yaml.schemas": {
+					"https://raw.githubusercontent.com/score-spec/schema/main/score-v1b1.json": "score.yaml"
+				}
+			}
+		}
+	}
+}

--- a/templates/podinfo-example/content/.devcontainer/installMoreTools.sh
+++ b/templates/podinfo-example/content/.devcontainer/installMoreTools.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+mkdir install-more-tools
+cd install-more-tools
+
+SCORE_COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/score-spec/score-compose/releases/latest | jq -r .tag_name)
+wget https://github.com/score-spec/score-compose/releases/download/${SCORE_COMPOSE_VERSION}/score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+tar -xvf score-compose_${SCORE_COMPOSE_VERSION}_linux_amd64.tar.gz
+chmod +x score-compose
+sudo mv score-compose /usr/local/bin
+
+HUMCTL_VERSION=$(curl -sL https://api.github.com/repos/humanitec/cli/releases/latest | jq -r .tag_name)
+curl -fLO https://github.com/humanitec/cli/releases/download/${HUMCTL_VERSION}/cli_${HUMCTL_VERSION:1}_linux_amd64.tar.gz
+tar -xvf cli_${HUMCTL_VERSION:1}_linux_amd64.tar.gz
+chmod +x humctl
+sudo mv humctl /usr/local/bin/humctl
+
+KIND_VERSION=$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r .tag_name)
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+cd ..
+rm -rf install-more-tools

--- a/templates/podinfo-example/content/Makefile
+++ b/templates/podinfo-example/content/Makefile
@@ -11,16 +11,15 @@ help:
 .PHONY: .FORCE
 .FORCE:
 
-WORKLOAD_NAME = node-workload
-CONTAINER_NAME = node-service
+WORKLOAD_NAME = podinfo-workload
+CONTAINER_NAME = podinfo
 CONTAINER_IMAGE = ${CONTAINER_NAME}:test
 
 compose.yaml: score.yaml
 	score-compose init \
 		--no-sample
 	score-compose generate score.yaml \
-		--build '${CONTAINER_NAME}={"context":".","tags":["${CONTAINER_IMAGE}"]}' \
-		--override-property containers.${CONTAINER_NAME}.variables.MESSAGE="Hello, Compose!"
+		--build '${CONTAINER_NAME}={"context":".","tags":["${CONTAINER_IMAGE}"]}'
 
 ## Generate a compose.yaml file from the score spec and launch it.
 .PHONY: compose-up

--- a/templates/podinfo-example/content/score.yaml
+++ b/templates/podinfo-example/content/score.yaml
@@ -1,7 +1,7 @@
 apiVersion: score.dev/v1b1
 
 metadata:
-  name: ${{ values.name | dump }}
+  name: podinfo-workload
 
 service:
   ports:
@@ -10,7 +10,7 @@ service:
       targetPort: 9898 # The port that the container will be listening on
 
 containers:
-  frontend:
+  podinfo:
     image: . # Set by pipeline
     variables:
       Hello: World


### PR DESCRIPTION
- Fix Node.js 16 actions are deprecated
- Optimize `node-service`'s container image and bump to `alpine:3.19.1`
- Fix CVEs: `mysql2 3.9.7` for `node-service`
- Add `devcontainer` for `node-service` and `podinfo`, great way to demo VS Code lint, `score-compose`, `humctl` already pre-installed
- `Makefile` / `score-compose` for `node-service` and `podinfo`
- `node-service` - add `MESSAGE` and MySQL `version`/`host`
- Update App, versus Workload, versus Container names to avoid confusion