### PR TITLE
Fix Kind issue in Moby/Docker 27 in `.devcontainer`

### DIFF
--- a/templates/5min-node-service/content/.devcontainer/devcontainer.json
+++ b/templates/5min-node-service/content/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
-			"version": "latest"
+			"_comment": "cannot use latest for now because of this current issue: https://github.com/kubernetes-sigs/kind/issues/3696",
+			"version": "26.1.4"
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
 			"version": "latest",

--- a/templates/5min-podinfo/content/.devcontainer/devcontainer.json
+++ b/templates/5min-podinfo/content/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
-			"version": "latest"
+			"_comment": "cannot use latest for now because of this current issue: https://github.com/kubernetes-sigs/kind/issues/3696",
+			"version": "26.1.4"
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
 			"version": "latest",

--- a/templates/node-service/content/.devcontainer/devcontainer.json
+++ b/templates/node-service/content/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
-			"version": "latest"
+			"_comment": "cannot use latest for now because of this current issue: https://github.com/kubernetes-sigs/kind/issues/3696",
+			"version": "26.1.4"
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
 			"version": "latest",

--- a/templates/podinfo-example/content/.devcontainer/devcontainer.json
+++ b/templates/podinfo-example/content/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"moby": true,
-			"version": "latest"
+			"_comment": "cannot use latest for now because of this current issue: https://github.com/kubernetes-sigs/kind/issues/3696",
+			"version": "26.1.4"
 		},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
 			"version": "latest",


### PR DESCRIPTION
When running `make kind-create-cluster` or `kind create cluster`, with the current default/`latest` version of Moby/Docker 27 in `.devcontainer`, we get this error:
```
Creating cluster "kind" ...
ERROR: failed to create cluster: failed to ensure docker network: command "docker network create -d=bridge -o com.docker.network.bridge.enable_ip_masquerade=true -o com.docker.network.driver.mtu=1500 --ipv6 --subnet fc00:f853:ccd:e793::/64 kind" failed with error: exit status 1
Command Output: Error response from daemon: Failed to Setup IP tables: Unable to enable NAT rule:  (iptables failed: ip6tables --wait -t nat -I POSTROUTING -s fc00:f853:ccd:e793::/64 ! -o br-4a6862c950c4 -j MASQUERADE: ip6tables v1.8.7 (legacy): can't initialize ip6tables table `nat': Table does not exist (do you need to insmod?)
Perhaps ip6tables or your kernel needs to be upgraded.
 (exit status 3))
```

This fix consists to fall back to the previous version of Moby/Docker 26 working for now in `.devcontainer`.