### PR TITLE
Bump GHA actions versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - if: ${{ vars.CLOUD_PROVIDER == 'aws' }}
         name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -62,7 +62,7 @@ jobs:
       - if: ${{ vars.CLOUD_PROVIDER == 'aws' }}
         name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -96,7 +96,7 @@ jobs:
 
       - if: ${{ vars.CLOUD_PROVIDER == 'gcp' }}
         name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/5min-node-service/content/.github/workflows/deploy.yaml
+++ b/templates/5min-node-service/content/.github/workflows/deploy.yaml
@@ -44,21 +44,21 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set Tag with SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-7`" >> $GITHUB_ENV
 {% endraw %}
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -91,7 +91,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/5min-node-service/content/.github/workflows/pull_request.yaml
+++ b/templates/5min-node-service/content/.github/workflows/pull_request.yaml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: humanitec/setup-cli-action@v1
         with:
           version: ${{ env.HUMCTL_VERSION }}
@@ -65,14 +65,14 @@ jobs:
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -105,7 +105,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/5min-podinfo/content/.github/workflows/deploy.yaml
+++ b/templates/5min-podinfo/content/.github/workflows/deploy.yaml
@@ -48,21 +48,21 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set Tag with SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-7`" >> $GITHUB_ENV
 {% endraw %}
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -95,7 +95,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/5min-podinfo/content/.github/workflows/pull_request.yaml
+++ b/templates/5min-podinfo/content/.github/workflows/pull_request.yaml
@@ -49,7 +49,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: humanitec/setup-cli-action@v1
         with:
           version: ${{ env.HUMCTL_VERSION }}
@@ -69,14 +69,14 @@ jobs:
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -109,7 +109,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/node-service/content/.github/workflows/deploy.yaml
+++ b/templates/node-service/content/.github/workflows/deploy.yaml
@@ -44,21 +44,21 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set Tag with SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-7`" >> $GITHUB_ENV
 {% endraw %}
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -91,7 +91,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/node-service/content/.github/workflows/pull_request.yaml
+++ b/templates/node-service/content/.github/workflows/pull_request.yaml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: humanitec/setup-cli-action@v1
         with:
           version: ${{ env.HUMCTL_VERSION }}
@@ -65,14 +65,14 @@ jobs:
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -105,7 +105,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/podinfo-example/content/.github/workflows/deploy.yaml
+++ b/templates/podinfo-example/content/.github/workflows/deploy.yaml
@@ -44,21 +44,21 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set Tag with SHA
         run: echo "TAG=`echo $GITHUB_SHA | cut -c 1-7`" >> $GITHUB_ENV
 {% endraw %}
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -91,7 +91,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}

--- a/templates/podinfo-example/content/.github/workflows/pull_request.yaml
+++ b/templates/podinfo-example/content/.github/workflows/pull_request.yaml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: humanitec/setup-cli-action@v1
         with:
           version: ${{ env.HUMCTL_VERSION }}
@@ -65,14 +65,14 @@ jobs:
 {%- if values.cloudProvider === "aws" -%}
 {% raw %}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: login to aws ecr
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
 
@@ -105,7 +105,7 @@ jobs:
 {%- elif values.cloudProvider === "gcp" -%}
 {% raw %}
       - name: configure gcp credentials
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
To avoid this:
```
Build & Notify Humanitec
The following actions use a deprecated Node.js version and will be forced to run on node20: google-github-actions/auth@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```
And this:
```
Build & Notify Humanitec
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, google-github-actions/auth@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

Tested there:
- https://github.com/htc-workshop-2024-10-30/backstage/commit/1a74f9030adfe9d858d90e916182d2112eebe82a
- https://github.com/htc-workshop-2024-10-30/test/commit/987d0bc8d4e130b7a262e70ea3ca5bd2170e8f6a

Fixing:
- https://github.com/htc-workshop-2024-10-30/backstage/pull/3
- https://github.com/htc-workshop-2024-10-30/backstage/pull/2
- https://github.com/htc-workshop-2024-10-30/backstage/pull/1