### PR TITLE
Fix `--workload-source-url` in PR

### DIFF
--- a/templates/5min-node-service/content/.github/workflows/pull_request.yaml
+++ b/templates/5min-node-service/content/.github/workflows/pull_request.yaml
@@ -140,7 +140,7 @@ jobs:
               --env ${{ env.ENVIRONMENT_ID }} \
               -f score.yaml \
               --extensions humanitec.score.yaml \
-              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/score.yaml" \
+              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.head_ref }}/score.yaml" \
               --image $CONTAINER_REGISTRY/$IMAGE:$TAG \
               --message "$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.event.pull_request.commits_url }}?per_page=10" | jq -r .[-1].commit.message)" \
               --wait

--- a/templates/5min-podinfo/content/.github/workflows/pull_request.yaml
+++ b/templates/5min-podinfo/content/.github/workflows/pull_request.yaml
@@ -150,7 +150,7 @@ jobs:
               --env ${{ env.ENVIRONMENT_ID }} \
               -f score.yaml \
               --extensions humanitec.score.yaml \
-              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/score.yaml" \
+              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.head_ref }}/score.yaml" \
               --image $CONTAINER_REGISTRY/$IMAGE:$TAG \
               --message "$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.event.pull_request.commits_url }}?per_page=10" | jq -r .[-1].commit.message)" \
               --wait          

--- a/templates/node-service/content/.github/workflows/pull_request.yaml
+++ b/templates/node-service/content/.github/workflows/pull_request.yaml
@@ -140,7 +140,7 @@ jobs:
               --env ${{ env.ENVIRONMENT_ID }} \
               -f score.yaml \
               --extensions humanitec.score.yaml \
-              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/score.yaml" \
+              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.head_ref }}/score.yaml" \
               --image $CONTAINER_REGISTRY/$IMAGE:$TAG \
               --message "$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.event.pull_request.commits_url }}?per_page=10" | jq -r .[-1].commit.message)" \
               --wait

--- a/templates/podinfo-example/content/.github/workflows/pull_request.yaml
+++ b/templates/podinfo-example/content/.github/workflows/pull_request.yaml
@@ -140,7 +140,7 @@ jobs:
               --env ${{ env.ENVIRONMENT_ID }} \
               -f score.yaml \
               --extensions humanitec.score.yaml \
-              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/score.yaml" \
+              --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.head_ref }}/score.yaml" \
               --image $CONTAINER_REGISTRY/$IMAGE:$TAG \
               --message "$(curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.event.pull_request.commits_url }}?per_page=10" | jq -r .[-1].commit.message)" \
               --wait


### PR DESCRIPTION
Otherwise getting with `${{ github.ref_name }}`:
```
https://github.com/htc-workshop-2024-10-30/podinfo/blob/2/merge/score.yaml
```
Landing to a `404`, instead of getting the actual file like this with `${{ github.head_ref }}`:
```
https://github.com/htc-workshop-2024-10-30/podinfo/blob/mathieu-benoit-patch-2/score.yaml
```