### PR TITLE
no `humctl create artefact-version` in PR

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   deploy:
-    name: Build & Notify Humanitec
+    name: Build & Deploy
     runs-on: ubuntu-latest
 
     permissions:
@@ -130,7 +130,7 @@ jobs:
         with:
           version: ${{ env.HUMCTL_VERSION }}
 
-      - name: Inform Humanitec
+      - name: Define container image metadata
         run: |-
           humctl create artefact-version \
             --token ${{ secrets.HUMANITEC_TOKEN }} \
@@ -141,7 +141,7 @@ jobs:
             --ref $GITHUB_REF \
             --commit $GITHUB_SHA
 
-      - name: Run Score
+      - name: Deploy Score
         run: |
           humctl score deploy \
             --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/5min-node-service/content/.github/workflows/deploy.yaml
+++ b/templates/5min-node-service/content/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ env:
 {% raw %}
 jobs:
   deploy:
-    name: Build & Notify Humanitec
+    name: Build & Deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -110,7 +110,7 @@ jobs:
         with:
           version: ${{ env.HUMCTL_VERSION }}
 
-      - name: Inform Humanitec
+      - name: Define container image metadata
         run: |-
           humctl create artefact-version \
             --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/5min-node-service/content/.github/workflows/pull_request.yaml
+++ b/templates/5min-node-service/content/.github/workflows/pull_request.yaml
@@ -120,18 +120,7 @@ jobs:
       - run: docker build --platform linux/amd64 . -t $CONTAINER_REGISTRY/$IMAGE:$TAG
       - run: docker push $CONTAINER_REGISTRY/$IMAGE:$TAG
 
-      - name: Inform Humanitec
-        run: |-
-          humctl create artefact-version \
-            --token ${{ secrets.HUMANITEC_TOKEN }} \
-            --org ${{ vars.HUMANITEC_ORG_ID }} \
-            -t container \
-            -n $CONTAINER_REGISTRY/$IMAGE \
-            --version $TAG \
-            --ref $GITHUB_REF \
-            --commit $GITHUB_SHA
-
-      - name: Run Score
+      - name: Deploy Score
         run: |
           humctl score deploy \
               --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/5min-podinfo/content/.github/workflows/deploy.yaml
+++ b/templates/5min-podinfo/content/.github/workflows/deploy.yaml
@@ -42,7 +42,7 @@ env:
 {% raw %}
 jobs:
   deploy:
-    name: Build & Notify Humanitec
+    name: Build & Deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -120,7 +120,7 @@ jobs:
         with:
           version: ${{ env.HUMCTL_VERSION }}
 
-      - name: Inform Humanitec
+      - name: Define container image metadata
         run: |-
           humctl create artefact-version \
             --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/5min-podinfo/content/.github/workflows/pull_request.yaml
+++ b/templates/5min-podinfo/content/.github/workflows/pull_request.yaml
@@ -130,18 +130,7 @@ jobs:
       - run: docker build . -t $CONTAINER_REGISTRY/$IMAGE:$TAG
       - run: docker push $CONTAINER_REGISTRY/$IMAGE:$TAG
 
-      - name: Inform Humanitec
-        run: |-
-          humctl create artefact-version \
-            --token ${{ secrets.HUMANITEC_TOKEN }} \
-            --org ${{ vars.HUMANITEC_ORG_ID }} \
-            -t container \
-            -n $CONTAINER_REGISTRY/$IMAGE \
-            --version $TAG \
-            --ref $GITHUB_REF \
-            --commit $GITHUB_SHA          
-
-      - name: Run Score
+      - name: Deploy Score
         run: |
           humctl score deploy \
               --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/node-service/content/.github/workflows/deploy.yaml
+++ b/templates/node-service/content/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ env:
 {% raw %}
 jobs:
   deploy:
-    name: Build & Notify Humanitec
+    name: Build & Deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -110,7 +110,7 @@ jobs:
         with:
           version: ${{ env.HUMCTL_VERSION }}
 
-      - name: Inform Humanitec
+      - name: Define container image metadata
         run: |-
           humctl create artefact-version \
             --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/node-service/content/.github/workflows/pull_request.yaml
+++ b/templates/node-service/content/.github/workflows/pull_request.yaml
@@ -120,18 +120,7 @@ jobs:
       - run: docker build --platform linux/amd64 . -t $CONTAINER_REGISTRY/$IMAGE:$TAG
       - run: docker push $CONTAINER_REGISTRY/$IMAGE:$TAG
 
-      - name: Inform Humanitec
-        run: |-
-          humctl create artefact-version \
-            --token ${{ secrets.HUMANITEC_TOKEN }} \
-            --org ${{ vars.HUMANITEC_ORG_ID }} \
-            -t container \
-            -n $CONTAINER_REGISTRY/$IMAGE \
-            --version $TAG \
-            --ref $GITHUB_REF \
-            --commit $GITHUB_SHA
-
-      - name: Run Score
+      - name: Deploy Score
         run: |
           humctl score deploy \
               --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/podinfo-example/content/.github/workflows/deploy.yaml
+++ b/templates/podinfo-example/content/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ env:
 {% raw %}
 jobs:
   deploy:
-    name: Build & Notify Humanitec
+    name: Build & Deploy
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -116,7 +116,7 @@ jobs:
         with:
           version: ${{ env.HUMCTL_VERSION }}
 
-      - name: Inform Humanitec
+      - name: Define container image metadata
         run: |-
           humctl create artefact-version \
             --token ${{ secrets.HUMANITEC_TOKEN }} \

--- a/templates/podinfo-example/content/.github/workflows/pull_request.yaml
+++ b/templates/podinfo-example/content/.github/workflows/pull_request.yaml
@@ -120,18 +120,7 @@ jobs:
       - run: docker build --platform linux/amd64 . -t $CONTAINER_REGISTRY/$IMAGE:$TAG
       - run: docker push $CONTAINER_REGISTRY/$IMAGE:$TAG
 
-      - name: Inform Humanitec
-        run: |-
-          humctl create artefact-version \
-            --token ${{ secrets.HUMANITEC_TOKEN }} \
-            --org ${{ vars.HUMANITEC_ORG_ID }} \
-            -t container \
-            -n $CONTAINER_REGISTRY/$IMAGE \
-            --version $TAG \
-            --ref $GITHUB_REF \
-            --commit $GITHUB_SHA
-
-      - name: Run Score
+      - name: Deploy Score
         run: |
           humctl score deploy \
               --token ${{ secrets.HUMANITEC_TOKEN }} \


### PR DESCRIPTION
Simplification and show best practice by removing `humctl create artefact-version` in PRs.

Feedback from latest workshop, CC: @TobiasBabin 