### PR TITLE
`emptyDir` `volume` as a resource

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -149,7 +149,6 @@ jobs:
             --app ${{ env.HUMANITEC_APP_ID }} \
             --env ${{ env.DEPLOYMENT_ENV }} \
             -f ${{ env.SCORE_FILE }} \
-            --extensions humanitec.score.yaml \
             --workload-source-url "https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/score.yaml" \
             --image $CONTAINER_REGISTRY/$IMAGE:$TAG \
             --message "${{ github.event.head_commit.message }}"

--- a/humanitec.score.yaml
+++ b/humanitec.score.yaml
@@ -1,6 +1,0 @@
-apiVersion: humanitec.org/v1b1
-profile: humanitec/default-module
-spec:
-  volumes:
-    tmp:
-      type: emptyDir

--- a/score.yaml
+++ b/score.yaml
@@ -56,7 +56,7 @@ containers:
             ${resources.env.GITHUB_APP_PRIVATE_KEY}
 
     volumes:
-    - source: volumes.tmp
+    - source: ${resources.empty-dir}
       target: /tmp
       readOnly: false
 
@@ -73,3 +73,5 @@ resources:
       port: 7007
   db:
     type: postgres
+  empty-dir:
+    type: volume


### PR DESCRIPTION
A `volume` res def needs to exist in the Humanitec Orchestrator:
```
apiVersion: entity.humanitec.io/v1b1
kind: Definition
metadata:
  id: volume-emptydir
entity:
  name: volume-emptydir
  type: volume
  driver_type: humanitec/template
  driver_inputs:
    values:
      templates:
        manifests:
          emptydir.yaml:
            location: volumes
            data: |
              name: ${context.res.guresid}-emptydir
              emptyDir:
                sizeLimit: 1024Mi
  criteria:
  - {}
```

Done in the different ref archs:
- https://github.com/humanitec-architecture/reference-architecture-gcp/pull/32
- https://github.com/humanitec-architecture/reference-architecture-aws/pull/32

Tested in a live instance: https://github.com/htc-kubecon-na-2024/backstage.