### PR TITLE
Pointing to templates v0.1.0

### DIFF
--- a/app-config.5min.yaml
+++ b/app-config.5min.yaml
@@ -47,11 +47,11 @@ catalog:
     - type: file
       target: catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/main/5min-node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/5min-node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/main/5min-podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/5min-podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: file

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -25,11 +25,11 @@ catalog:
     - type: url
       target: https://github.com/${GITHUB_ORG_ID}/backstage/blob/main/catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/main/node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/main/podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: url

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -47,11 +47,11 @@ catalog:
     - type: file
       target: ../../catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/main/node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/main/podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: file


### PR DESCRIPTION
https://github.com/humanitec-architecture/backstage-catalog-templates/releases/tag/v0.1.0


There is no really changes between `main` and `v0.1.0` at this point. It's more to start tracking versioning of the templates from this Backstage instance. Anticipating further improvements there. Just a good practice to not point to `main` or `latest`.