### PR TITLE
[WIP] pointing to templates v0.2.0

### DIFF
--- a/app-config.5min.yaml
+++ b/app-config.5min.yaml
@@ -47,11 +47,11 @@ catalog:
     - type: file
       target: catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/5min-node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.0/5min-node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/5min-podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.0/5min-podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: file

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -25,11 +25,11 @@ catalog:
     - type: url
       target: https://github.com/${GITHUB_ORG_ID}/backstage/blob/main/catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.0/node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.0/podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: url

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -47,11 +47,11 @@ catalog:
     - type: file
       target: ../../catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.0/node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.1.0/podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.0/podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: file


### PR DESCRIPTION
WIP, in preparation of future release.

The release notes will include:
- New way to scaffold a new App in Humanitec: not anymore via the Backstage plugin, but by now triggering the GHA: https://github.com/humanitec-architecture/backstage/blob/main/.github/workflows/onboard-humanitec-app.yaml.
- This is to show best practices and real world scenarios where onboarding a new Humanitec App is more than just create it, it's about other objects to create: `config`, Members assignement, Service Users/token creation, etc.
- This required that the Backstage instance point to the coming v0.2.0 templates
- This requires that `create-gh-app` setup when creating the Backstage instance is deployed, use version `v0.1.0`+: https://github.com/humanitec-architecture/create-gh-app/releases/tag/v0.1.0
- This new behavior is just for `nodeservice` and `podinfo` templates. On the other hand, `5min-podinfo` and `5min-nodeservice` will still use the "old way" via the Backstage plugin.