### PR TITLE
Update Dockerfile - `mirror.gcr.io/`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY plugins plugins
 RUN find packages \! -name "package.json" -mindepth 2 -maxdepth 2 -exec rm -rf {} \+
 
 # Stage 2 - Install dependencies and build packages
-FROM node:20-bookworm-slim AS build
+FROM mirror.gcr.io/node:20-bookworm-slim AS build
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://backstage.io/docs/deployment/docker/#multi-stage-build
 # Stage 1 - Create yarn install skeleton layer
-FROM node:20-bookworm-slim AS packages
+FROM mirror.gcr.io/node:20-bookworm-slim AS packages
 
 WORKDIR /app
 COPY package.json yarn.lock ./
@@ -49,7 +49,7 @@ RUN mkdir packages/backend/dist/skeleton packages/backend/dist/bundle \
     && tar xzf packages/backend/dist/bundle.tar.gz -C packages/backend/dist/bundle
 
 # Stage 3 - Build the actual backend image and install production dependencies
-FROM node:20-bookworm-slim
+FROM mirror.gcr.io/node:20-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 # Additionally, we install dependencies for `techdocs.generator.runIn: local`.

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -25,11 +25,11 @@ catalog:
     - type: url
       target: https://github.com/${GITHUB_ORG_ID}/backstage/blob/main/catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.1/node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.2/node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.1/podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.2/podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: url

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -47,11 +47,11 @@ catalog:
     - type: file
       target: ../../catalog-info.yaml
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.1/node-service/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.2/node-service/template.yaml
       rules:
         - allow: [Template]
     - type: url
-      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.1/podinfo/template.yaml
+      target: https://github.com/humanitec-architecture/backstage-catalog-templates/blob/v0.2.2/podinfo/template.yaml
       rules:
         - allow: [Template]
     - type: file

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 
-FROM node:20-bookworm-slim
+FROM mirror.gcr.io/node:20-bookworm-slim
 
 # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
Use `mirror.gcr.io/` to avoid DockerHub rate limits error while using this Backstage sample:
- https://docs.docker.com/docker-hub/usage/
- https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images
- https://devtron.ai/blog/dodging-docker-hub-rate-limits-the-ultimate-cheat-code-for-your-ci-cd-pipeline/

> Starting April 1, 2025, all users with a Pro, Team, or Business subscription will have unlimited Docker Hub pulls with fair use. Unauthenticated users and users with a free Personal account have the following pull limits:
> - Unauthenticated users: 10 pulls/hour
> - Authenticated users with a free account: 100 pulls/hour